### PR TITLE
Some fixes

### DIFF
--- a/alignak_webui/htdocs/css/alignak_webui-items.css
+++ b/alignak_webui/htdocs/css/alignak_webui-items.css
@@ -7,8 +7,6 @@
 /* Teals */
 .turquoise { color: #1abc9c; }
 .item_user,
-.item_hostgroup_unknown,
-.item_realm_unknown,
 .green-sea { color: #16a085; }
 
 /* Greens */
@@ -29,6 +27,12 @@
 
 /* Blues */
 .item_unknown,
+.item_hostgroup_unreachable,
+.item_realm_unreachable,
+.item_daemon_unreachable,
+.item_host_unreachable,
+.item_service_unreachable,
+.item_logcheckresult_unreachable,
 .peter-river { color: #3498db; }
 .item_service_unknown,
 .item_logcheckresult_unknown,
@@ -66,16 +70,13 @@
 .orange { color: #f39c12; }
 
 /* Oranges */
-.item_hostgroup_warning,
-.item_realm_warning,
 .item_close,
 .item_inactive,
 .sla_hosts_warning,
 .sla_services_warning,
-.item_daemon_unreachable,
-.item_host_unreachable,
+.item_hostgroup_warning,
+.item_realm_warning,
 .item_host_warning,
-.item_logcheckresult_unreachable,
 .item_service_warning,
 .item_logcheckresult_warning,
 .carrot { color: #e67e22; }
@@ -85,6 +86,7 @@
 .item_hostgroup_critical,
 .item_realm_critical,
 .item_daemon_down,
+.item_daemon_critical,
 .item_host_down,
 .item_host_critical,
 .item_service_critical,

--- a/alignak_webui/objects/datamanager.py
+++ b/alignak_webui/objects/datamanager.py
@@ -1566,7 +1566,8 @@ class DataManager(object):
         if embedded and 'embedded' not in search:
             search.update({
                 'embedded': {
-                    '_realm': 1, '_templates': 1,
+                    # '_realm': 1,
+                    '_templates': 1,
                     'host': 1,
                     'check_command': 1, 'snapshot_command': 1, 'event_handler': 1,
                     'check_period': 1, 'notification_period': 1,
@@ -1808,12 +1809,12 @@ class DataManager(object):
             search = {}
         if 'sort' not in search:
             search.update({'sort': 'name'})
-        if 'embedded' not in search:
-            search.update({
-                'embedded': {
-                    '_realm': 1
-                }
-            })
+        # if 'embedded' not in search:
+        #     search.update({
+        #         'embedded': {
+        #             '_realm': 1
+        #         }
+        #     })
 
         try:
             logger.debug("get_commands, search: %s", search)
@@ -1847,7 +1848,7 @@ class DataManager(object):
         if 'embedded' not in search:
             search.update({
                 'embedded': {
-                    '_realm': 1,
+                    # '_realm': 1,
                     '_parent': 1
                 }
             })
@@ -2085,12 +2086,12 @@ class DataManager(object):
             search = {}
         if 'sort' not in search:
             search.update({'sort': 'name'})
-        if 'embedded' not in search:
-            search.update({
-                'embedded': {
-                    '_realm': 1
-                }
-            })
+        # if 'embedded' not in search:
+        #     search.update({
+        #         'embedded': {
+        #             '_realm': 1
+        #         }
+        #     })
 
         try:
             logger.debug("get_timeperiods, search: %s", search)

--- a/alignak_webui/objects/item_command.py
+++ b/alignak_webui/objects/item_command.py
@@ -47,14 +47,14 @@ class Command(BackendElement):
         """
         Create a History (called only once when an object is newly created)
         """
-        self._linked__realm = 'realm'
+        # self._linked__realm = 'realm'
 
         super(Command, self).__init__(params, date_format, embedded)
 
-    @property
-    def _realm(self):
-        """ Return concerned realm """
-        return self._linked__realm
+    # @property
+    # def _realm(self):
+    #     """ Return concerned realm """
+    #     return self._linked__realm
 
     @property
     def endpoint(self):

--- a/alignak_webui/objects/item_service.py
+++ b/alignak_webui/objects/item_service.py
@@ -77,7 +77,7 @@ class Service(BackendElement):
 
         """Create a service (called only once when an object is newly created)"""
 
-        self._linked__realm = 'realm'
+        # self._linked__realm = 'realm'
         self._linked__templates = 'service'
         self._linked_host = 'host'
         self._linked_check_command = 'command'
@@ -105,10 +105,10 @@ class Service(BackendElement):
         """
         return '/service/%s' % (self.id)
 
-    @property
-    def _realm(self):
-        """ Return concerned realm """
-        return self._linked__realm
+    # @property
+    # def _realm(self):
+    #     """ Return concerned realm """
+    #     return self._linked__realm
 
     @property
     def _templates(self):

--- a/alignak_webui/objects/item_timeperiod.py
+++ b/alignak_webui/objects/item_timeperiod.py
@@ -55,14 +55,14 @@ class TimePeriod(BackendElement):
         """
         Create a timeperiod (called only once when an object is newly created)
         """
-        self._linked__realm = 'realm'
+        # self._linked__realm = 'realm'
 
         super(TimePeriod, self).__init__(params, date_format, embedded)
 
-    @property
-    def _realm(self):
-        """ Return group parent """
-        return self._linked__realm
+    # @property
+    # def _realm(self):
+    #     """ Return group parent """
+    #     return self._linked__realm
 
     @property
     def endpoint(self):

--- a/alignak_webui/plugins/currently/currently.py
+++ b/alignak_webui/plugins/currently/currently.py
@@ -29,6 +29,7 @@ from bottle import request
 
 from alignak_webui import _
 from alignak_webui.utils.plugin import Plugin
+from alignak_webui.utils.helper import Helper
 
 # pylint: disable=invalid-name
 logger = getLogger(__name__)
@@ -49,6 +50,11 @@ class PluginCurrently(Plugin):
                 'name': 'Currently',
                 'route': '/currently',
                 'view': 'currently'
+            },
+            'get_currently_bis': {
+                'name': 'Currently',
+                'route': '/currently_bis',
+                'view': 'currently_bis'
             }
         }
 
@@ -77,5 +83,71 @@ class PluginCurrently(Plugin):
             'history': ls_history,
             'hs': livesynthesis['hosts_synthesis'],
             'ss': livesynthesis['services_synthesis'],
+            'title': request.query.get('title', _('Keep an eye'))
+        }
+
+    def get_currently_bis(self):  # pylint:disable=no-self-use, too-many-locals
+        """
+        Display currently page
+        """
+        user = request.environ['beaker.session']['current_user']
+        datamgr = request.app.datamgr
+
+        # Default states
+        hosts_states = ['up', 'down', 'unreachable']
+        services_states = ['ok', 'warning', 'critical', 'unreachable', 'unknown']
+
+        # Get the stored panels in user's preferences
+        currently_panels = datamgr.get_user_preferences(user, 'currently_panels', None)
+        if not currently_panels:
+            currently_panels = {
+                'panel_counters_hosts': {'collapsed': False},
+                'panel_counters_services': {'collapsed': False},
+                'panel_percentage_hosts': {'collapsed': False},
+                'panel_percentage_services': {'collapsed': False},
+                'panel_pie_graph_hosts': {'collapsed': False},
+                'panel_pie_graph_services': {'collapsed': False},
+                'panel_line_graph_hosts': {'collapsed': False},
+                'panel_line_graph_services': {'collapsed': False}
+            }
+
+        # Get the stored graphs
+        currently_graphs = datamgr.get_user_preferences(user, 'currently_graphs', None)
+        if not currently_graphs:
+            currently_graphs = {
+                'pie_graph_hosts': {'legend': True, 'title': True, 'states': hosts_states},
+                'pie_graph_services': {'legend': True, 'title': True, 'states': services_states},
+                'line_graph_hosts': {'legend': True, 'title': True, 'states': hosts_states},
+                'line_graph_services': {'legend': True, 'title': True, 'states': services_states}
+            }
+
+        # Live state global and history
+        (livesynthesis, ls_history) = datamgr.get_livesynthesis_history()
+        hs = livesynthesis['hosts_synthesis']
+        ss = livesynthesis['services_synthesis']
+        ls_history = sorted(ls_history, key=lambda x: x['_timestamp'], reverse=False)
+
+        collapsed = currently_panels['panel_counters_hosts']['collapsed']
+        pc_h = Helper.get_html_hosts_count_panel(hs, self.webui.get_url('Hosts table'),
+                                                 collapsed=collapsed, percentage=False)
+
+        collapsed = currently_panels['panel_percentage_hosts']['collapsed']
+        pp_h = Helper.get_html_hosts_count_panel(hs, self.webui.get_url('Hosts table'),
+                                                 collapsed=collapsed, percentage=True)
+
+        collapsed = currently_panels['panel_counters_services']['collapsed']
+        pc_s = Helper.get_html_services_count_panel(ss, self.webui.get_url('Services table'),
+                                                    collapsed=collapsed, percentage=False)
+
+        collapsed = currently_panels['panel_percentage_services']['collapsed']
+        pp_s = Helper.get_html_services_count_panel(ss, self.webui.get_url('Services table'),
+                                                    collapsed=collapsed, percentage=True)
+
+        return {
+            'currently_panels': currently_panels,
+            'panel_counters_hosts': pc_h,
+            'panel_percentage_hosts': pc_s,
+            'panel_counters_services': pp_h,
+            'panel_percentage_services': pp_s,
             'title': request.query.get('title', _('Keep an eye'))
         }

--- a/alignak_webui/plugins/currently/views/currently.tpl
+++ b/alignak_webui/plugins/currently/views/currently.tpl
@@ -38,7 +38,7 @@
 %end
 
 %#Set this to True to reset saved parameters
-%create_graphs_preferences = True
+%create_graphs_preferences = False
 %if create_graphs_preferences or not 'display_states' in currently_graphs['pie_graph_hosts']:
 %currently_graphs['pie_graph_hosts']['display_states'] = {}
 %currently_graphs['line_graph_hosts']['display_states'] = {}
@@ -55,9 +55,21 @@
 %create_graphs_preferences = True
 %end
 
+<style>
+div.pull-right a, div.pull-right div {
+   margin-top: 0px; margin-bottom: 0px;
+}
+.hosts-count, .services-count {
+   font-size: 24px;
+}
+.hosts-state, .services-state {
+   font-size: 12px;
+}
+</style>
+
 <div id="currently">
 <script type="text/javascript">
-   var dashboard_logs = true;
+   var dashboard_logs = false;
 
    // Application globals
    dashboard_currently = true;
@@ -136,8 +148,8 @@
             sessionStorage.setItem("services_problems", services_problems);
 
             // Hosts pie chart
-            if ($("#panel_pie_graph_hosts").is(":visible") && ! panels["panel_pie_graph_hosts"].collapsed) {
-               if (dashboard_logs) console.debug('Refresh: panel_pie_graph_hosts', graphs['pie_graph_hosts']);
+            if (panels && $("#panel_pie_graph_hosts").is(":visible") && ! panels["panel_pie_graph_hosts"].collapsed) {
+               if (dashboard_logs) console.debug('Refresh: panel_pie_graph_hosts', panels["panel_pie_graph_hosts"]);
                var data=[], labels=[], colors=[], hover_colors=[];
                $.each(graphs['pie_graph_hosts']['display_states'], function(state, active) {
                   if (! active) return;
@@ -177,8 +189,8 @@
             }
 
             // Hosts line chart
-            if ($("#panel_line_graph_hosts").is(":visible") && ! panels["panel_line_graph_hosts"].collapsed) {
-               if (dashboard_logs) console.debug('Refresh: panel_line_graph_hosts', graphs['line_graph_hosts']);
+            if (panels && $("#panel_line_graph_hosts").is(":visible") && ! panels["panel_line_graph_hosts"].collapsed) {
+               if (dashboard_logs) console.debug('Refresh: panel_line_graph_hosts', panels["panel_line_graph_hosts"]);
                var labels=[];
                %idx=len(history)
                %for ls in history:
@@ -259,8 +271,8 @@
             }
 
             // Services pie chart
-            if ($("#panel_pie_graph_services").is(":visible") && ! panels["panel_pie_graph_services"].collapsed) {
-               if (dashboard_logs) console.debug('Refresh: panel_pie_graph_services', graphs['pie_graph_services']);
+            if (panels && $("#panel_pie_graph_services").is(":visible") && ! panels["panel_pie_graph_services"].collapsed) {
+               if (dashboard_logs) console.debug('Refresh: panel_pie_graph_services', panels["panel_pie_graph_services"]);
                var data=[], labels=[], colors=[], hover_colors=[];
                $.each(graphs['pie_graph_services']['display_states'], function(state, active) {
                   if (! active) return;
@@ -301,8 +313,8 @@
             }
 
             // Services line chart
-            if ($("#panel_line_graph_services").is(":visible") && ! panels["panel_line_graph_services"].collapsed) {
-               if (dashboard_logs) console.debug('Refresh: panel_line_graph_services', graphs['line_graph_services']);
+            if (panels && $("#panel_line_graph_services").is(":visible") && ! panels["panel_line_graph_services"].collapsed) {
+               if (dashboard_logs) console.debug('Refresh: panel_line_graph_services', panels["panel_line_graph_services"]);
                var labels=[];
                %idx=len(history)
                %for ls in history:
@@ -411,17 +423,6 @@
    });
 </script>
 
-<style>
-div.pull-right a, div.pull-right div {
-   margin-top: 0px; margin-bottom: 0px;
-}
-.hosts-count, .services-count {
-   font-size: 24px;
-}
-.hosts-state, .services-state {
-   font-size: 12px;
-}
-</style>
 <nav id="topbar" class="navbar navbar-fixed-top">
    <div id="one-eye-toolbar" class="col-xs-12">
       <ul class="nav navbar-nav navbar-left">
@@ -486,7 +487,7 @@ div.pull-right a, div.pull-right div {
             </div>
             <div id="p_panel_counters_hosts" class="panel-collapse collapse {{'in' if not currently_panels['panel_counters_hosts']['collapsed'] else ''}}">
                <div class="panel-body">
-                  %for state in 'up', 'unreachable', 'down', 'acknowledged', 'in_downtime':
+                  %for state in 'up', 'unreachable', 'down':
                   <div class="col-xs-4 col-sm-4 col-md-2 text-center">
                      <a href="{{ webui.get_url('Hosts table') }}?search=ls_state:{{state.upper()}}" class="item_host_{{state}}" title="{{ state }}">
                         <span class="hosts-count" data-count="{{ hs['nb_' + state] }}" data-state="{{ state }}">{{ hs['nb_' + state] }}</span>
@@ -495,6 +496,17 @@ div.pull-right a, div.pull-right div {
                      </a>
                   </div>
                   %end
+                  <div class="col-xs-4 col-sm-4 col-md-2 text-center">
+                     %state='acknowledged'
+                     <a href="{{ webui.get_url('Hosts table') }}?search=ls_state:{{state.upper()}}" class="item_host_{{state}}" title="{{ state }}">
+                        <span class="hosts-count" data-count="{{ hs['nb_' + state] }}" data-state="{{ state }}">{{ hs['nb_' + state] }}</span>
+                     </a>
+                     <span>/</span>
+                     %state='in_downtime'
+                     <a href="{{ webui.get_url('Hosts table') }}?search=ls_state:{{state.upper()}}" class="item_host_{{state}}" title="{{ state }}">
+                        <span class="hosts-count" data-count="{{ hs['nb_' + state] }}" data-state="{{ state }}">{{ hs['nb_' + state] }}</span>
+                     </a>
+                  </div>
                </div>
             </div>
          </div>
@@ -512,16 +524,24 @@ div.pull-right a, div.pull-right div {
              </div>
             <div id="p_panel_counters_services" class="panel-collapse collapse {{'in' if not currently_panels['panel_counters_services']['collapsed'] else ''}}">
                <div class="panel-body">
-                  %for state in 'ok', 'warning', 'critical', 'unreachable', 'unknown', 'acknowledged', 'in_downtime':
+                  %for state in 'ok', 'warning', 'critical', 'unreachable', 'unknown':
                   <div class="col-xs-4 col-sm-4 col-md-2 text-center">
-                     %label = "%d<br/><em>(%s)</em>" % (ss['nb_' + state], state)
                      <a role="button" href="{{ webui.get_url('Services table') }}?search=ls_state:{{state.upper()}}" class="item_service_{{state}}" title="{{ state }}">
                         <span class="services-count" data-count="{{ ss['nb_' + state] }}" data-state="{{ state }}">{{ ss['nb_' + state] }}</span>
-                        <!-- <br/>
-                        <span class="services-state">{{ state }}</span> -->
                      </a>
                   </div>
                   %end
+                  <div class="col-xs-4 col-sm-4 col-md-2 text-center">
+                     %state='acknowledged'
+                     <a role="button" href="{{ webui.get_url('Services table') }}?search=ls_state:{{state.upper()}}" class="item_service_{{state}}" title="{{ state }}">
+                        <span class="services-count" data-count="{{ ss['nb_' + state] }}" data-state="{{ state }}">{{ ss['nb_' + state] }}</span>
+                     </a>
+                     <span>/</span>
+                     %state='in_downtime'
+                     <a role="button" href="{{ webui.get_url('Services table') }}?search=ls_state:{{state.upper()}}" class="item_service_{{state}}" title="{{ state }}">
+                        <span class="services-count" data-count="{{ ss['nb_' + state] }}" data-state="{{ state }}">{{ ss['nb_' + state] }}</span>
+                     </a>
+                  </div>
                </div>
             </div>
          </div>
@@ -542,38 +562,54 @@ div.pull-right a, div.pull-right div {
             </div>
             <div id="p_panel_percentage_hosts" class="panel-collapse collapse {{'in' if not currently_panels['panel_percentage_hosts']['collapsed'] else ''}}">
                <div class="panel-body">
-                  <!-- Hosts SLA icons -->
-                  <div class="col-xs-4 col-sm-4 text-center">
-                     <div class="col-xs-12 text-center">
-                        %sla = (100 - hs['pct_up'])
-                        %font='ok' if sla >= 95.0 else 'warning' if sla >= 90.0 else 'critical'
-                        <a href="{{ webui.get_url('Hosts table') }}" class="sla_hosts_{{font}}">
-                           <div>{{sla}}%</div>
+                   <div class="row">
+                      <!-- Hosts SLA icons -->
+                      <div class="col-xs-3 col-sm-3 text-center">
+                         <div class="col-xs-12 text-center">
+                            %sla = hs['pct_up']
+                            %font='ok' if sla >= 95.0 else 'warning' if sla >= 90.0 else 'critical'
+                            <a href="{{ webui.get_url('Hosts table') }}" class="sla_hosts_{{font}}">
+                               <div>{{sla}}%</div>
+                               <i class="fa fa-4x fa-server"></i>
+                               <p>{{_('Hosts SLA')}}</p>
+                            </a>
+                         </div>
+                      </div>
 
-                           <i class="fa fa-4x fa-server"></i>
-                           <p>{{_('Hosts SLA')}}</p>
-                        </a>
-                     </div>
-                     %known_problems=hs['nb_acknowledged']+hs['nb_in_downtime']+hs['nb_problems']
-                     %pct_known_problems=round(100.0 * known_problems / hs['nb_elts'], 2) if hs['nb_elts'] else -1
-                     <div class="col-xs-12 text-center">
-                        <a role="button" href="{{ webui.get_url('Hosts table') }}?search=ls_state:down" class="sla_hosts_problems">
-                           <span class="hosts-count" data-count="{{ known_problems }}" data-state="problem">{{ pct_known_problems }}%</span>
-                           <br/>
-                           <span class="hosts-state">{{_('Known problems')}}</span>
-                        </a>
-                     </div>
-                  </div>
+                      %for state in 'up', 'unreachable', 'down':
+                      <div class="col-xs-3 col-sm-3 col-md-3 text-center">
+                         <a role="button" href="{{ webui.get_url('Hosts table') }}?search=ls_state:{{state.upper()}}" class="item_host_{{state}}" title="{{ state }}">
+                            <span class="hosts-count" data-count="{{ hs['nb_' + state] }}" data-state="{{ state }}">{{ hs['pct_' + state] }}%</span>
+                            <br/>
+                            <span class="hosts-state">{{ state }}</span>
+                         </a>
+                      </div>
+                      %end
+                   </div>
+                   <div class="row">
+                      <!-- Hosts SLA icons -->
+                      <div class="col-xs-3 col-sm-3 text-center">
+                         %unmanaged_problems=hs['nb_problems'] - (hs['nb_acknowledged']+hs['nb_in_downtime'])
+                         %pct_unmanaged_problems=round(100.0 * unmanaged_problems / hs['nb_elts'], 2) if hs['nb_elts'] else -1
+                         <div class="col-xs-12 text-center">
+                            <a role="button" href="{{ webui.get_url('Hosts table') }}?search=ls_state:down" class="sla_hosts_problems">
+                               <span class="hosts-count" data-count="{{ hs['nb_problems'] }}" data-state="problem">{{ pct_unmanaged_problems }}%</span>
+                               <br/>
+                               <span class="hosts-state">{{_('Unmanaged problems')}}</span>
+                            </a>
+                         </div>
+                      </div>
 
-                  %for state in 'up', 'unreachable', 'down', 'acknowledged', 'in_downtime':
-                  <div class="col-xs-4 col-sm-4 col-md-2 text-center">
-                     <a role="button" href="{{ webui.get_url('Hosts table') }}?search=ls_state:{{state.upper()}}" class="item_host_{{state}}" title="{{ state }}">
-                        <span class="hosts-count" data-count="{{ hs['nb_' + state] }}" data-state="{{ state }}">{{ hs['pct_' + state] }}%</span>
-                        <!-- <br/>
-                        <span class="hosts-state">{{ state }}</span> -->
-                     </a>
-                  </div>
-                  %end
+                      %for state in 'acknowledged', 'in_downtime':
+                      <div class="col-xs-3 col-sm-3 col-md-3 text-center">
+                         <a role="button" href="{{ webui.get_url('Hosts table') }}?search=ls_state:{{state.upper()}}" class="item_host_{{state}}" title="{{ state }}">
+                            <span class="hosts-count" data-count="{{ hs['nb_' + state] }}" data-state="{{ state }}">{{ hs['pct_' + state] }}%</span>
+                            <br/>
+                            <span class="hosts-state">{{ state }}</span>
+                         </a>
+                      </div>
+                      %end
+                   </div>
                </div>
             </div>
             </div>
@@ -592,37 +628,53 @@ div.pull-right a, div.pull-right div {
             <div id="p_panel_percentage_services" class="panel-collapse collapse {{'in' if not currently_panels['panel_percentage_services']['collapsed'] else ''}}">
                <div class="panel-body">
                   <!-- Services SLA icons -->
-                  <div class="col-xs-4 col-sm-4 text-center">
-                     <div class="col-xs-12 text-center">
-                        %sla = (100 - ss['pct_ok'])
-                        %font='ok' if sla >= 95.0 else 'warning' if sla >= 90.0 else 'critical'
-                        <a href="/all?search=type:service" class="sla_services_{{font}}">
-                           <div>{{sla}}%</div>
+                  <div class="row">
+                      <div class="col-xs-3 col-sm-3 text-center">
+                         <div class="col-xs-12 text-center">
+                            %sla = ss['pct_ok']
+                            %font='ok' if sla >= 95.0 else 'warning' if sla >= 90.0 else 'critical'
+                            <a href="/all?search=type:service" class="sla_services_{{font}}">
+                               <div>{{sla}}%</div>
 
-                           <i class="fa fa-4x fa-server font-{{font}}"></i>
-                           <p>{{_('Services SLA')}}</p>
-                        </a>
-                     </div>
-                     %known_problems=ss['nb_acknowledged']+ss['nb_in_downtime']+ss['nb_problems']
-                     %pct_known_problems=round(100.0 * known_problems / ss['nb_elts'], 2) if ss['nb_elts'] else -1
-                     <div class="col-xs-12 text-center">
-                         <a role="button" href="{{ webui.get_url('Services table') }}?search=ls_state:down" class="sla_services_problems">
-                             <span class="services-count" data-count="{{ known_problems }}" data-state="problem">{{ pct_known_problems }}%</span>
-                             <br/>
-                             <span class="services-state">{{_('Known problems')}}</span>
-                         </a>
-                     </div>
-                  </div>
+                               <i class="fa fa-4x fa-server font-{{font}}"></i>
+                               <p>{{_('Services SLA')}}</p>
+                            </a>
+                         </div>
+                      </div>
 
-                  %for state in 'ok', 'warning', 'critical', 'unreachable', 'unknown', 'acknowledged', 'in_downtime':
-                  <div class="col-xs-4 col-sm-4 text-center">
-                      <a role="button" href="{{ webui.get_url('Services table') }}?search=ls_state:{{state.upper()}}" class="item_service_{{state}}">
-                          <span class="services-count" data-count="{{ ss['nb_' + state] }}" data-state="{{ state }}">{{ ss['pct_' + state] }}%</span>
-                          <br/>
-                          <span class="services-state">{{ state }}</span>
-                      </a>
+                      %for state in 'ok', 'warning', 'critical', 'unreachable', 'unknown':
+                      <div class="col-xs-3 col-sm-3 col-md-3 text-center">
+                          <a role="button" href="{{ webui.get_url('Services table') }}?search=ls_state:{{state.upper()}}" class="item_service_{{state}}">
+                              <span class="services-count" data-count="{{ ss['nb_' + state] }}" data-state="{{ state }}">{{ ss['pct_' + state] }}%</span>
+                              <br/>
+                              <span class="services-state">{{ state }}</span>
+                          </a>
+                      </div>
+                      %end
                   </div>
-                  %end
+                  <div class="row">
+                      <div class="col-xs-3 col-sm-3 text-center">
+                         %unmanaged_problems=ss['nb_problems'] - (ss['nb_acknowledged']+ss['nb_in_downtime'])
+                         %pct_unmanaged_problems=round(100.0 * unmanaged_problems / ss['nb_elts'], 2) if ss['nb_elts'] else -1
+                         <div class="col-xs-12 text-center">
+                             <a role="button" href="{{ webui.get_url('Services table') }}?search=ls_state:down" class="sla_services_problems">
+                                 <span class="services-count" data-count="{{ ss['nb_problems'] }}" data-state="problem">{{ pct_unmanaged_problems }}%</span>
+                                 <br/>
+                                 <span class="services-state">{{_('Unmanaged problems')}}</span>
+                             </a>
+                         </div>
+                      </div>
+
+                      %for state in 'acknowledged', 'in_downtime':
+                      <div class="col-xs-3 col-sm-3 col-md-3 text-center">
+                          <a role="button" href="{{ webui.get_url('Services table') }}?search=ls_state:{{state.upper()}}" class="item_service_{{state}}">
+                              <span class="services-count" data-count="{{ ss['nb_' + state] }}" data-state="{{ state }}">{{ ss['pct_' + state] }}%</span>
+                              <br/>
+                              <span class="services-state">{{ state }}</span>
+                          </a>
+                      </div>
+                      %end
+                  </div>
                </div>
             </div>
          </div>

--- a/alignak_webui/plugins/currently/views/currently_bis.tpl
+++ b/alignak_webui/plugins/currently/views/currently_bis.tpl
@@ -1,0 +1,151 @@
+%from bottle import request
+
+%setdefault('refresh', True)
+%rebase("fullscreen", css=[], js=[], title=title)
+
+%import json
+
+<style>
+div.pull-right a, div.pull-right div {
+   margin-top: 0px; margin-bottom: 0px;
+}
+.hosts-count, .services-count {
+   font-size: 24px;
+}
+.hosts-state, .services-state {
+   font-size: 12px;
+}
+</style>
+
+<div id="currently">
+    <script type="text/javascript">
+        // Application globals
+        dashboard_currently = true;
+
+        // Panels user's preferences
+        currently_panels = {{ ! json.dumps(currently_panels) }};
+    </script>
+
+    <nav id="topbar" class="navbar navbar-fixed-top">
+       <div id="one-eye-toolbar" class="col-xs-12">
+          <ul class="nav navbar-nav navbar-left">
+             <li>
+                <a tabindex="0" role="button"
+                   data-toggle="tooltip" data-placement="bottom"
+                   title="{{_('Go back to the dashboard')}}" href="/dashboard">
+                   <span class="fa fa-home"></span>
+                   <span class="sr-only">{{_('Go back to the main dashboard')}}</span>
+                </a>
+             </li>
+             <li>
+                <a tabindex="0" role="button"
+                   data-action="fullscreen-request"
+                   data-toggle="tooltip" data-placement="bottom"
+                   title="{{_('Fullscreen page')}}" href="#">
+                   <span class="fa fa-desktop"></span>
+                   <span class="sr-only">{{_('Fullscreen page')}}</span>
+                </a>
+             </li>
+             %if request.app.config.get('play_sound', 'no') == 'yes':
+             <li id="sound_alerting">
+                <a tabindex="0" role="button"
+                   data-action="toggle-sound-alert"
+                   data-toggle="tooltip" data-placement="bottom"
+                   title="{{_('Sound alert on/off')}}" href="#">
+                   <span class="fa fa-music"></span>
+                   <span class="sr-only">{{_('Change sound playing state')}}</span>
+                </a>
+             </li>
+             %end
+          </ul>
+
+          <ul class="nav navbar-nav navbar-right">
+             <li>
+                <p class="navbar-text font-darkgrey">
+                   <span id="date"></span>&nbsp;&hyphen;&nbsp;<span id="clock"></span>
+                </p>
+             </li>
+          </ul>
+       </div>
+    </nav>
+
+    %if request.app.config.get('play_sound', 'no') == 'yes':
+       %include("_sound_play.tpl")
+    %end
+
+    <div class="row" style="margin-top:60px;">
+        <div id="one-eye-hosts-counters" class="col-xs-12 col-md-6">
+          {{! panel_counters_hosts }}
+        </div>
+        <div id="one-eye-services-counters" class="col-xs-12 col-md-6">
+          {{! panel_counters_services }}
+        </div>
+
+        <div id="one-eye-hosts-percentages" class="col-xs-12 col-md-6">
+          {{! panel_percentage_hosts }}
+        </div>
+        <div id="one-eye-services-percentages" class="col-xs-12 col-md-6">
+          {{! panel_percentage_services }}
+        </div>
+    </div>
+
+    <div class="row" style="margin-top:60px;">
+        <div id="livestate-graphs" class="col-xs-12">
+        </div>
+    </div>
+
+    <script type="text/javascript">
+        // Function called on each page refresh ... update graphs!
+        function on_page_refresh(forced) {
+        };
+
+        $(document).ready(function(){
+            on_page_refresh();
+
+            // Date / time
+            $('#clock').jclock({ format: '%H:%M:%S' });
+            $('#date').jclock({ format: '%A, %B %d' });
+
+            // Fullscreen management
+            if (screenfull.enabled) {
+                $('a[data-action="fullscreen-request"]').on('click', function() {
+                    screenfull.request();
+                });
+
+                // Fullscreen changed event
+                document.addEventListener(screenfull.raw.fullscreenchange, function () {
+                    if (screenfull.isFullscreen) {
+                        $('a[data-action="fullscreen-request"]').hide();
+                    } else {
+                        $('a[data-action="fullscreen-request"]').show();
+                    }
+                });
+            }
+        });
+
+        // Panels collapse state
+        $('.panel').on('hidden.bs.collapse', function () {
+            wait_message('{{_('Saving configuration...')}}', true)
+
+            console.log($(this).parent().attr('id'));
+            currently_panels[$(this).parent().attr('id')].collapsed = true;
+            $(this).find('.fa-minus-square').removeClass('fa-minus-square').addClass('fa-plus-square');
+            save_user_preference('currently_panels', JSON.stringify(currently_panels), function() {
+                wait_message('', false)
+                // Page refresh required
+                refresh_required = true;
+            });
+        });
+        $('.panel').on('shown.bs.collapse', function () {
+            wait_message('{{_('Saving configuration...')}}', true)
+
+            currently_panels[$(this).parent().attr('id')].collapsed = false;
+            $(this).find('.fa-plus-square').removeClass('fa-plus-square').addClass('fa-minus-square');
+            save_user_preference('currently_panels', JSON.stringify(currently_panels), function() {
+                wait_message('', false)
+                // Page refresh required
+                refresh_required = true;
+            });
+        });
+    </script>
+</div>

--- a/alignak_webui/plugins/hostgroups/views/hostgroup.tpl
+++ b/alignak_webui/plugins/hostgroups/views/hostgroup.tpl
@@ -122,6 +122,7 @@
                   <th style="width: 40px"></th>
                   <th>{{_('Host name')}}</th>
                   <th>{{_('Business impact')}}</th>
+                  <th>{{_('Host check')}}</th>
                   <th>{{_('Last check')}}</th>
                   <th>{{_('Output')}}</th>
                </tr></thead>
@@ -130,8 +131,7 @@
                %for elt in element.members:
                   <tr id="#{{elt.id}}">
                      <td title="{{elt.alias}}">
-                        %title = "%s - %s (%s)" % (elt.state, Helper.print_duration(elt.last_check, duration_only=True, x_elts=0), elt.output)
-                        {{! elt.get_html_state(text=None, title=title)}}
+                        {{! elt.get_html_state(text=None, size="fa-1x", use_status=elt.overall_status)}}
                      </td>
 
                      <td title="{{elt.alias}}">
@@ -140,6 +140,10 @@
 
                      <td>
                         <small>{{! Helper.get_html_business_impact(elt.business_impact)}}</small>
+                     </td>
+
+                     <td>
+                        {{! elt.get_html_state(text=None)}}
                      </td>
 
                      <td>

--- a/alignak_webui/plugins/hosts/settings.cfg
+++ b/alignak_webui/plugins/hosts/settings.cfg
@@ -400,9 +400,8 @@ default=False
 [table.freshness_threshold]
 title=Freshness threshold
 type=integer
-default=120
-visible=False
-hidden=True
+default=3600
+visible=True
 
 [table.freshness_state]
 title=Freshness state
@@ -516,7 +515,7 @@ type=boolean
 title=Acknowledged
 editable=False
 
-[table.ls_downtime]
+[table.ls_downtimed]
 type=boolean
 title=In scheduled downtime
 editable=False

--- a/alignak_webui/plugins/hosts/views/host_grafana_widget.tpl
+++ b/alignak_webui/plugins/hosts/views/host_grafana_widget.tpl
@@ -20,7 +20,7 @@
    %if host.ls_grafana and host.ls_grafana_panelid:
    %dashboard_name = host.name.replace('.', '-')
    %panel_id = host.ls_grafana_panelid
-   <iframe src="{{grafana_url}}/dashboard-solo/db/host_{{dashboard_name}}?panelId={{panel_id}}" width="100%" height="320" frameborder="0"></iframe>
+   <iframe src="{{grafana_url}}/dashboard-solo/db/host-{{dashboard_name}}?panelId={{panel_id}}" width="100%" height="320" frameborder="0"></iframe>
    %else:
    <div class="alert alert-info">
       <p class="font-blue">{{_('No Grafana panel available for %s.' % host.name)}}</p>
@@ -31,7 +31,7 @@
       %if service.ls_grafana and service.ls_grafana_panelid:
       %dashboard_name = host.name.replace('.', '-')
       %panel_id = service.ls_grafana_panelid
-      <iframe class="embed-responsive-item" src="{{grafana_url}}/dashboard-solo/db/host_{{dashboard_name}}?panelId={{panel_id}}" width="100%" height="240" frameborder="0"></iframe>
+      <iframe class="embed-responsive-item" src="{{grafana_url}}/dashboard-solo/db/host-{{dashboard_name}}?panelId={{panel_id}}" width="100%" height="240" frameborder="0"></iframe>
       %else:
       <!--
       <div class="alert alert-info">

--- a/alignak_webui/plugins/realms/views/realm.tpl
+++ b/alignak_webui/plugins/realms/views/realm.tpl
@@ -123,6 +123,7 @@
                   <th style="width: 40px"></th>
                   <th>{{_('Host name')}}</th>
                   <th>{{_('Business impact')}}</th>
+                  <th>{{_('Host check')}}</th>
                   <th>{{_('Last check')}}</th>
                   <th>{{_('Output')}}</th>
                </tr></thead>
@@ -131,8 +132,7 @@
                %for elt in members:
                   <tr id="#{{elt.id}}">
                      <td title="{{elt.alias}}">
-                        %title = "%s - %s (%s)" % (elt.state, Helper.print_duration(elt.last_check, duration_only=True, x_elts=0), elt.output)
-                        {{! elt.get_html_state(text=None, title=title)}}
+                        {{! elt.get_html_state(text=None, size="fa-1x", use_status=elt.overall_status)}}
                      </td>
 
                      <td title="{{elt.alias}}">
@@ -141,6 +141,10 @@
 
                      <td>
                         <small>{{! Helper.get_html_business_impact(elt.business_impact)}}</small>
+                     </td>
+
+                     <td>
+                        {{! elt.get_html_state(text=None)}}
                      </td>
 
                      <td>

--- a/alignak_webui/plugins/services/settings.cfg
+++ b/alignak_webui/plugins/services/settings.cfg
@@ -318,9 +318,8 @@ default=False
 [table.freshness_threshold]
 title=Freshness threshold
 type=integer
-default=120
-visible=False
-hidden=True
+default=3600
+visible=True
 
 [table.freshness_state]
 title=Freshness state
@@ -510,7 +509,7 @@ type=boolean
 title=Acknowledged
 visible=True
 
-[table.ls_downtime]
+[table.ls_downtimed]
 type=boolean
 title=In scheduled downtime
 visible=True

--- a/alignak_webui/plugins/services/views/service.tpl
+++ b/alignak_webui/plugins/services/views/service.tpl
@@ -149,7 +149,8 @@
          %end
       </div>
       %end
-      %if templates:
+      %#todo: edit the service templates!
+      %if False:
       <div class="btn-group pull-right">
          %if len(templates) > 2:
             <button class="btn btn-info btn-xs dropdown-toggle" data-toggle="dropdown">

--- a/alignak_webui/plugins/services/views/service_grafana_widget.tpl
+++ b/alignak_webui/plugins/services/views/service_grafana_widget.tpl
@@ -20,7 +20,7 @@
    %if service.ls_grafana and service.ls_grafana_panelid:
    %dashboard_name = service.host.name.replace('.', '-')
    %panel_id = service.ls_grafana_panelid
-   <iframe src="{{grafana_url}}/dashboard-solo/db/host_{{dashboard_name}}?panelId={{panel_id}}" width="100%" height="320" frameborder="0"></iframe>
+   <iframe src="{{grafana_url}}/dashboard-solo/db/host-{{dashboard_name}}?panelId={{panel_id}}" width="100%" height="320" frameborder="0"></iframe>
    %else:
    <!--
    <div class="alert alert-info">

--- a/alignak_webui/plugins/timeperiods/settings.cfg
+++ b/alignak_webui/plugins/timeperiods/settings.cfg
@@ -59,6 +59,7 @@ visible=False
 [table.is_active]
 title=Currently active
 type=boolean
+visible=False
 editable=False
 
 [table.dateranges]

--- a/alignak_webui/utils/datatable.py
+++ b/alignak_webui/utils/datatable.py
@@ -581,9 +581,13 @@ class Datatable(object):
 
         # Change item content ...
         rows = []
+        # Total number of filtered records
+        self.records_filtered = self.records_total
         for item in items:
             bo_object = object_class(item)
             logger.debug("table data object: %s", bo_object)
+            # Each item contains the toal number of records matching the search filter
+            self.records_filtered = item['_total']
 
             row = {}
             row['DT_RowData'] = {}
@@ -687,14 +691,8 @@ class Datatable(object):
             # logger.debug("Table row: %s", row)
             rows.append(row)
 
-        # Total number of filtered records
-        self.records_filtered = self.records_total
-        if 'where' in parameters and parameters['where'] != {}:
-            logger.debug("update filtered records: %s", parameters['where'])
-            self.records_filtered = len(items)
-        logger.info(
-            "filtered records: %d out of total: %d", self.records_filtered, self.records_total
-        )
+        logger.debug("filtered records: %d out of total: %d",
+                     self.records_filtered, self.records_total)
 
         # Prepare response
         rsp = {

--- a/test/test_datatable.py
+++ b/test/test_datatable.py
@@ -394,7 +394,7 @@ class TestDataTable(unittest2.TestCase):
         response_value = response.json
         print(response_value)
         assert response.json['recordsTotal'] == self.items_count
-        assert response.json['recordsFiltered'] == 5
+        assert response.json['recordsFiltered'] == 90
         assert response.json['data']
         assert len(response.json['data']) == 5
 
@@ -492,7 +492,7 @@ class TestDataTable(unittest2.TestCase):
         response_value = response.json
         print(response_value)
         assert response.json['recordsTotal'] == self.items_count
-        assert response.json['recordsFiltered'] == 5
+        assert response.json['recordsFiltered'] == 88
         assert response.json['data']
         assert len(response.json['data']) == 5
 
@@ -631,7 +631,7 @@ class TestDatatableHosts(TestDatatableBase):
             '<th data-name="ls_state_type" data-type="string">State type</th>',
             '<th data-name="ls_state_id" data-type="integer">State id</th>',
             '<th data-name="ls_acknowledged" data-type="boolean">Acknowledged</th>',
-            '<th data-name="ls_downtime" data-type="boolean">In scheduled downtime</th>',
+            '<th data-name="ls_downtimed" data-type="boolean">In scheduled downtime</th>',
             '<th data-name="ls_output" data-type="string">Output</th>',
             '<th data-name="ls_long_output" data-type="string">Long output</th>',
             '<th data-name="ls_perf_data" data-type="string">Performance data</th>',
@@ -779,7 +779,7 @@ class TestDatatableServices(TestDatatableBase):
             '<th data-name="ls_state_type" data-type="string">State type</th>',
             '<th data-name="ls_state_id" data-type="integer">State id</th>',
             '<th data-name="ls_acknowledged" data-type="boolean">Acknowledged</th>',
-            '<th data-name="ls_downtime" data-type="boolean">In scheduled downtime</th>',
+            '<th data-name="ls_downtimed" data-type="boolean">In scheduled downtime</th>',
             '<th data-name="ls_output" data-type="string">Output</th>',
             '<th data-name="ls_long_output" data-type="string">Long output</th>',
             '<th data-name="ls_perf_data" data-type="string">Performance data</th>',

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -136,17 +136,8 @@ class TestDashboard(unittest2.TestCase):
             '<!-- Page footer -->'
         )
 
-        print('get page /currently')
-        redirected_response = self.app.get('/currently')
-        redirected_response.mustcontain(
-            '<div id="currently">',
-            '<div id="one-eye-toolbar"',
-            '<div id="one-eye-overall" ',
-            '<div id="one-eye-icons" ',
-        )
 
-
-class TestUsers(unittest2.TestCase):
+class TestCurrently(unittest2.TestCase):
     def setUp(self):
         # Test application
         self.app = TestApp(
@@ -157,20 +148,19 @@ class TestUsers(unittest2.TestCase):
     def tearDown(self):
         response = self.app.get('/logout')
 
-    def test_users(self):
-        """ Web - users """
-        print('test users')
+    def test_dashboard(self):
+        """ Web - dashboard """
+        print('test currently')
 
-        print('get page /users')
-        response = self.app.get('/users')
-        response.mustcontain(
-            '<div id="users">',
-            '5 elements out of 5',
+        print('get page /currently')
+        redirected_response = self.app.get('/currently')
+        redirected_response.mustcontain(
+            '<div id="currently">',
+            '<div id="one-eye-toolbar"',
+            '<div id="one-eye-overall" ',
+            '<div id="one-eye-icons" ',
+            '<div id="livestate-graphs" ',
         )
-        self.app.get('/users/config')
-        self.app.get('/users/list')
-        self.app.get('/users/table')
-        self.app.get('/users/templates')
 
 
 class TestCommands(unittest2.TestCase):
@@ -665,6 +655,33 @@ class TestServices(unittest2.TestCase):
         response.mustcontain(
             '<div id="service-%s">' % self.service_id
         )
+
+
+class TestUsers(unittest2.TestCase):
+    def setUp(self):
+        # Test application
+        self.app = TestApp(
+            webapp
+        )
+        response = self.app.post('/login', {'username': 'admin', 'password': 'admin'})
+
+    def tearDown(self):
+        response = self.app.get('/logout')
+
+    def test_users(self):
+        """ Web - users """
+        print('test users')
+
+        print('get page /users')
+        response = self.app.get('/users')
+        response.mustcontain(
+            '<div id="users">',
+            '5 elements out of 5',
+        )
+        self.app.get('/users/config')
+        self.app.get('/users/list')
+        self.app.get('/users/table')
+        self.app.get('/users/templates')
 
 
 class TestWorldmap(unittest2.TestCase):


### PR DESCRIPTION
No button to recheck not actively checked hosts/services
Remove link to realm when no really useful
Properly display downtime state for host/service in tables
Hide timeperiod is_active in the table
Fix #112: broken pagination for templated items
Clean hostgroup view
Clean one-eye view
Display Freshness threshold in the hosts/services table
Update items icons colors
Prepare currently view update
Set version as 0.6.16.5