### PR TITLE
Closes #110 - session duration management

### DIFF
--- a/alignak_webui/app.py
+++ b/alignak_webui/app.py
@@ -971,14 +971,19 @@ TEMPLATE_PATH.append(
 # Extend default WSGI application with a session middleware
 # -----
 session_opts = {
-    'session.type': 'file',
-    'session.data_dir': os.path.join('/tmp', __manifest__['name'], 'sessions'),
-    'session.auto': True,
-    'session.cookie_expires': 21600,    # 6 hours
-    'session.key': __manifest__['name'],
-    'sesssion.webtest_varname': __manifest__['name'],    # For unit tests ...
-    'session.data_serializer': 'json'   # Default is pickle ... not appropriate for our data!
+    'session.type': app.config.get('session.type', 'file'),
+    'session.data_dir': app.config.get('session.data_dir',
+                                       os.path.join('/tmp', __manifest__['name'], 'sessions')),
+    'session.auto': app.config.get('session.auto', True),
+    'session.cookie_expires': app.config.get('session.cookie_expires', 43200),
+    'session.key': app.config.get('session.key', __manifest__['name']),
+    'session.save_accessed_time': True,
+    'session.timeout': app.config.get('session.timeout', None),
+    'session.data_serializer': app.config.get('session.data_serializer', 'json'),
+    # Do not remove! For unit tests only...
+    'sesssion.webtest_varname': __manifest__['name'],
 }
+logger.debug("Session parameters: %s" % session_opts)
 session_app = SessionMiddleware(app, session_opts)
 
 if __name__ == '__main__':

--- a/docs/source/03_configuration/index.rst
+++ b/docs/source/03_configuration/index.rst
@@ -122,6 +122,14 @@ This section contains parameters to configure the base Web server.
     * **debug**, to make the server run in debug mode (only useful for developers)
 
 
+[session] section
+~~~~~~~~~~~~~~~~
+
+This section contains parameters to configure the application user's sessions. Thanks to those parameters it is possible to adapt the session duration according to your needs. This requires to be aware of the Web client / server session handling to make some modifications in this section.
+
+As a default, the user session is valid from the login time up to the client's browser closing, allowing to have infinite sessions to use the Web UI on stand-alone monitors;)
+
+
 [Alignak-WebUI] section
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/04_run/index.rst
+++ b/docs/source/04_run/index.rst
@@ -7,6 +7,19 @@
 Run
 ===
 
+Maintenance
+-----------
+
+The WebUI application uses the Beaker session middleware and it stores the user sessions in files in the */tmp/Alignak-WebUI/sessions* directory. You will need to remove the oldest files in this directory:
+::
+
+    find /tmp/Alignak-WebUI/sessions -mtime +3 -exec rm {} \;
+
+**Note** that most often the */tmp* directory is cleant on a regular basis and nothing special is to be done;)
+
+
+When using the WebUI with the provided script, some log files are stored in the */usr/local/var/log/alignak-webui* (or */var/log/alignak-webui*). Those files should also be handled else their size will grow indefinitely...
+
 Production mode
 ---------------
 

--- a/docs/source/05_use/index.rst
+++ b/docs/source/05_use/index.rst
@@ -15,10 +15,20 @@ Assuming the default configuration has not changed, you can point your Web brows
     http://localhost:5001/
 
 
-The application login page requires that a username and a password are typed. The user authentication
-is made by the Alignak backend with user accounts which have been previously created in the backend.
+The application login page requires that a username and a password are typed. The user authentication is made by the Alignak backend with user accounts which have been previously created in the backend.
 
 With the backend default configuration, it should exist an `admin` user whose password is `admin`.
+
+User session
+------------
+
+Assuming the default configuration has not changed, the user session will be alive as long as the logged-in user's web browser is not closed.
+
+
+Livestate
+---------
+
+The livestate page displays the current system live state
 
 
 Dashboard

--- a/etc/settings.cfg
+++ b/etc/settings.cfg
@@ -12,6 +12,32 @@ port = 5001
 debug = False
 
 ; ------------------------------------------------------------------------------------------
+; Configure Application session manager
+; Do not change anything in this section unless you are really aware of what you are doing!
+; Configuration is based upon: https://beaker.readthedocs.io/en/latest/configuration.html#session-options
+; ------------------------------------------------------------------------------------------
+[session]
+; Store sessions in files...
+;type=file
+; ... located in this directory
+;data_dir=/tmp/Alignak-WebUI/sessions
+; Data are stored as json in the sessions files
+;data_serializer=json
+
+; Session cookie life duration
+; Set to True, the cookie will expire on client's browser closing (default)
+; Set to False, the cookie will never expire
+; Set this value to a number of seconds to set an expiry duration
+;cookie_expires=True
+; Cookie identifier
+;key=Alignak-WebUI
+
+; Session life duration, defaults to never expire
+; Set this value to a number of seconds to set an expiry duration
+; Make the cookie and session expiry duration the same ;)
+;timeout=None
+
+; ------------------------------------------------------------------------------------------
 ; Configure WebUI application
 ; ------------------------------------------------------------------------------------------
 [alignak-webui]


### PR DESCRIPTION
Session default duration is infinite
Session may be configured in the application settings.cfg file