### PR TITLE
Disabled the refresh for the edition forms

### DIFF
--- a/alignak_webui/views/_form.tpl
+++ b/alignak_webui/views/_form.tpl
@@ -8,6 +8,7 @@
 %setdefault('is_templated', '_is_template' in plugin.table)
 %setdefault('is_template', False)
 %setdefault('has_template', False)
+%setdefault('refresh', False)
 
 %if element:
 %# An element still exists...


### PR DESCRIPTION
In link with this [issue](https://github.com/Alignak-monitoring-contrib/alignak-webui/issues/277)

We set the refresh attribute to False for the _form view (To deactivate it)